### PR TITLE
Update README.md

### DIFF
--- a/src/Symfony/Component/Notifier/README.md
+++ b/src/Symfony/Component/Notifier/README.md
@@ -11,7 +11,7 @@ are not covered by Symfony's
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/current/components/notifier.html)
+  * [Documentation](https://symfony.com/doc/current/notifier.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The documentation URL in the readme is wrong. It sends to https://symfony.com/doc/current/components/notifier.html which then redirects back to https://github.com/symfony/notifier.

This PR fixes that to the correct URL: https://symfony.com/doc/current/notifier.html